### PR TITLE
Adds changes to V2 API for API provider

### DIFF
--- a/src/footbal.js
+++ b/src/footbal.js
@@ -1,9 +1,9 @@
 const axios = require('axios');
-const WORLD_CUP_URL = 'http://api.football-data.org/v1/competitions/467/fixtures';
+const WORLD_CUP_URL = 'http://api.football-data.org/v2/competitions/2267/matches';
 
 const getPlayingGames = async () => {
   const response = await axios.get(WORLD_CUP_URL);
-  return response.data.fixtures.filter(fixture => fixture.status === "IN_PLAY");
+  return response.data.matches.filter(match => match.status === "IN_PLAY");
 };
 
 const isTeamPlaying = async (team) => {

--- a/src/language.js
+++ b/src/language.js
@@ -11,7 +11,7 @@ const buildNationalTeamPlayingMessage = (people, countries) => {
     people,
     pluralPeople: people.length > 1,
     countries,
-    pluarlCountries: countries.length > 1
+    pluralCountries: countries.length > 1
   });
 };
 


### PR DESCRIPTION
This PR does an update for:
- Fix typo in language.js
- Moves API endpoints to V2 (V1 has reached EOL according to what their api answers). They have moved over to v2, as mentioned [here](https://www.football-data.org/documentation/api#changelog) and referenced [here](https://www.football-data.org/documentation/quickstart).

World cup still doesn't appear as competition yet, we should look to it later (2-3 months?) or perhaps look at an alternative provider.